### PR TITLE
chore: add pgvector extension to schema

### DIFF
--- a/db-schema/schema.sql
+++ b/db-schema/schema.sql
@@ -11,6 +11,7 @@ SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
 
+CREATE EXTENSION IF NOT EXISTS vector;
 
 CREATE SCHEMA IF NOT EXISTS "public";
 


### PR DESCRIPTION
### Fixes
- Users not having the pgvector extension already installed got the following error while setting up the DB:

                `type public.vector does not exist`
