### PR TITLE
fix: issue with pgvector extension

### DIFF
--- a/db-schema/schema.sql
+++ b/db-schema/schema.sql
@@ -11,7 +11,8 @@ SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
 
-CREATE EXTENSION IF NOT EXISTS vector;
+CREATE EXTENSION IF NOT EXISTS vector WITH SCHEMA public;
+
 
 CREATE SCHEMA IF NOT EXISTS "public";
 


### PR DESCRIPTION
- Users reported getting the error `type public.vector does not exist`. This change fixes this issue.